### PR TITLE
Add new commands to clean up resources & assets

### DIFF
--- a/Classes/Command/ResourceToolsCommandController.php
+++ b/Classes/Command/ResourceToolsCommandController.php
@@ -120,7 +120,7 @@ final class ResourceToolsCommandController extends CommandController
      *
      * @param string $source Can be anything PHP can open (filepath, URL, data string, etc.)
      * @param string $filename The filename (if empty string it will try to fetch from stream or leave empty)
-     * @param string $collection
+     * @param string $collection Name of the resource collection to import to. Default: "persistent"
      */
     public function importFileCommand(string $source, string $filename, string $collection = 'persistent'): void
     {

--- a/Classes/Command/ResourceToolsCommandController.php
+++ b/Classes/Command/ResourceToolsCommandController.php
@@ -33,7 +33,7 @@ final class ResourceToolsCommandController extends CommandController
     {
         if (!is_dir($targetPath)) {
             $this->outputLine('The target path does not exist.');
-            exit(1);
+            $this->quit(1);
         }
 
         $collectionInstance = $this->resourceManager->getCollection($collection);
@@ -82,7 +82,7 @@ final class ResourceToolsCommandController extends CommandController
     {
         if (!is_dir($sourcePath)) {
             $this->outputLine('<error>The source path does not exist.</error>');
-            exit(1);
+            $this->quit(1);
         }
 
         $collectionInstance = $this->resourceManager->getCollection($collection);
@@ -134,7 +134,7 @@ final class ResourceToolsCommandController extends CommandController
             $this->outputLine('Imported file as resource "%s"', [$resource->getSha1()]);
         } catch (Exception $e) {
             $this->outputLine('<error>Failed importing file</error>  %s', [$e->getMessage()]);
-            exit(1);
+            $this->quit(1);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -104,3 +104,8 @@ Neos:
           target: '\Flownative\ResourceTools\ResourceManagement\DummyTarget'
           targetOptions: []
 ``` 
+
+## Credits
+
+- This has been partly developed based on things our customers needed, so they paid some of it.
+- Inspiration also taken from https://github.com/networkteam/Networkteam.OrphanedResources

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "support@flownative.com"
     },
     "require": {
-        "neos/flow": "^7.0 || ^8.0 || dev-master"
+        "neos/flow": "^7.3 || ^8.0 || ^9.0 || dev-main"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds two new commands to the package.

**`removeOrphanedBlobs` command**

The new command allows to delete orphaned blobs (files) in `Data/Persistent/Resources`.

For the purpose of this command, orphans are blobs not attached to a persistent resources record in the database. 

**`removeUnusedAssets` command**

The new command allows to delete unused assets, their resources records, and their blobs.

For the purpose of this command, assets are considered unused if they are not having any use recorded by any of the installed `AssetUsageStrategyInterface` implementations.