### PR TITLE
FEATURE: Neos 9.0 compatibility

### DIFF
--- a/Classes/ResourceManagement/DummyTarget.php
+++ b/Classes/ResourceManagement/DummyTarget.php
@@ -83,4 +83,8 @@ class DummyTarget implements TargetInterface
     {
         return '';
     }
+
+    public function onPublish(\Closure $callback): void
+    {
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "support@flownative.com"
     },
     "require": {
-        "neos/flow": "^7.0 || ^8.0 || dev-master"
+        "neos/flow": "^7.0 || ^8.0 || ^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Adds Neos 9.0 compatibility. The TargetInterface of DummyTarget has changed in Neos 9, but is backwards compatibe as it only added the new `onPublish` method.